### PR TITLE
fix webkit Audio issue

### DIFF
--- a/player.js
+++ b/player.js
@@ -112,7 +112,7 @@ const playTone = function(frequency, duration, audioContext) {
 };
 
 // Setup a single shared audio context for the juke box.
-let jukeboxAudioContext = new webkitAudioContext();
+let jukeboxAudioContext = new AudioContext();
 
 // Play a given song at "bpm" beats per minute.
 // Calls "onComplete" when the song is over.


### PR DESCRIPTION
Demo Pull request: Looks like Chrome made some update that changes how webkitAudioContext works. Its now AudioContext instead.